### PR TITLE
App/MapView/web-bundling-fails ticket # 14

### DIFF
--- a/app/components/MapView/MapView.tsx
+++ b/app/components/MapView/MapView.tsx
@@ -1,0 +1,4 @@
+import MapView, { Marker, PROVIDER_DEFAULT, Region } from "react-native-maps";
+
+export { MapView, Marker, PROVIDER_DEFAULT };
+export type { Region };

--- a/app/components/MapView/MapView.web.tsx
+++ b/app/components/MapView/MapView.web.tsx
@@ -1,0 +1,13 @@
+import { forwardRef } from "react";
+import { View, Text } from "react-native";
+import { MapViewProps } from "react-native-maps";
+
+const MapView = forwardRef((props: MapViewProps, ref) => {
+	return (
+		<View>
+			<Text>Web MapView version still not implemented</Text>
+		</View>
+	);
+});
+
+export { MapView };


### PR DESCRIPTION
+ MapView component extended to help expo choose between native or web implementation.

Fixed issue #14 
Please reffer to issue ticket [Map module fails web bundling # 14](https://github.com/BraveVlad/matmon/issues/14) for further explanation.